### PR TITLE
ci: fix token permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # no need to bother caching bun deps
 # https://github.com/oven-sh/setup-bun/issues/14#issuecomment-1714116221
 jobs:
@@ -29,6 +32,9 @@ jobs:
     needs: changed-files
     if: needs.changed-files.outputs.any_ts_changed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,5 @@
 name: main
 on:
-  # push trigger required to get coveralls monitoring of default branch
-  # pull_request required to get PR coveralls comments
   push:
     branches: [main]
   pull_request:
@@ -11,8 +9,6 @@ on:
 permissions:
   contents: read
 
-# no need to bother caching bun deps
-# https://github.com/oven-sh/setup-bun/issues/14#issuecomment-1714116221
 jobs:
   changed-files:
     runs-on: ubuntu-latest
@@ -48,6 +44,7 @@ jobs:
 
   test:
     needs: _test
+    permissions: {}
     # workaround for https://github.com/orgs/community/discussions/13690
     # https://stackoverflow.com/a/77066140/9771158
     if: ${{ !(failure() || cancelled()) }}
@@ -57,6 +54,8 @@ jobs:
         run: exit 0
 
   check:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,4 +1,7 @@
 name: Semantic PR title
+permissions:
+  contents: read
+  pull-requests: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/sripwoud/ts-template/security/code-scanning/1](https://github.com/sripwoud/ts-template/security/code-scanning/1)

To resolve this issue, add an explicit `permissions` block at the top level of the workflow (or for the single job), assigning only the minimal permissions needed. Since this workflow uses an action to check the PR title formatting and does not appear to need to write to the repo or PR (e.g., comment, label, merge), it likely only needs to read pull request metadata. Therefore, set `contents: read` and `pull-requests: read` for the workflow. Update `.github/workflows/semantic-pr.yml` by adding this block after the `name:` line and before the `on:` line. No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
